### PR TITLE
Contrato CSV, prueba Bats y bitácora - Sprint 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 .DELETE_ON_ERROR:
 
-.PHONY: tools build test run pack clean help deps
+.PHONY: tools build test run package clean help deps
 
 SHELLCHECK :=shellcheck
 SHFMT :=shfmt
@@ -13,16 +13,15 @@ OUT_DIR :=out
 DIST_DIR :=dist
 all: tools lint build test package
 
-build: $(OUT_DIR)/monitor.log
-
+build: $(OUT_DIR)/monitor.log ## build dummy (evidencia)
 $(OUT_DIR)/monitor.log: $(SRC_DIR)/monitor.sh
 	mkdir -p $(@D)
 	$(SHELL) $< > $@
 
-test: $(TEST_DIR)/test_monitor.sh
-	bash $<
+test: ## ejecuta pruebas bats
+	bats $(TEST_DIR)
 
-package: $(DIST_DIR)/monitor.tar.gz
+package: $(DIST_DIR)/monitor.tar.gz ## Empaqueta artefactos determinísticamente
 
 $(DIST_DIR)/monitor.tar.gz: $(OUT_DIR)/monitor.log
 	mkdir -p $(@D)
@@ -43,5 +42,9 @@ tools: deps##este target verifica dependencias
 
 clean: ## target de limpieza
 	@rm -rf $(OUT_DIR) $(DIST_DIR)
+
 help: ## visualizacion de descripcion de targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':|##' '{printf " %s %s\n" ,$$1,$$3}'
+
+run: ## ejecuta monitor y genera CSV
+	@TARGETS=$${TARGETS:-https://example.com} $(SHELL) $(SRC_DIR)/monitor.sh

--- a/docs/Contrato-salidas.md
+++ b/docs/Contrato-salidas.md
@@ -1,5 +1,42 @@
+# Contrato de salida: `out/latencias.csv`
 
-## Script `check-endpoint.sh` para monitoreo de endpoints
+## Estudiante: Sanchez Vega Andre Alvaro
+
+### Definición formal (contrato)
+- Cabecera: `ts,target,http_code,time_ms`
+- Campos:
+  - ts → ISO 8601 UTC
+  - target → URL
+  - http_code → número de 3 dígitos
+  - time_ms → entero ≥ 0
+- Delimitador: `,`
+- Encoding: UTF-8
+- Reglas de evolución: cabecera fija, columnas extra solo en S2/S3.
+
+### Validar que existe al menos una fila de datos (además de cabecera)
+
+```bash
+[ "$(wc -l < out/latencias.csv)" -ge 2 ] echo "OK: tiene filas"
+```
+
+### Validar formato de cada fila: ts,target,http_code,time_ms
+```bash
+tail -n +2 out/latencias.csv | grep -Eq '^[^,]+,[^,]+,[0-9]{3},[0-9]+$' && echo "OK: formato válido"
+```
+
+### Ejemplo de contenido esperado
+```
+ts,target,http_code,time_ms
+2025-09-30T15:12:45Z,https://example.com,200,234
+2025-09-30T15:12:45Z,https://facebook.com/login,302,421
+```
+```
+OK: tiene filas
+OK: formato válido
+```
+## Estudiante: Quispe Villena Renzo
+
+### Script `check-endpoint.sh` para monitoreo de endpoints
 
 Comandos usados:
 
@@ -27,7 +64,7 @@ Tenemos que:
 - `http://github.com` respondió 301 (redirección a HTTPS) en 356 ms. Exit code = 1 por los fallos de conexión.
 
 
-#### Ejemplo de salida para endpoints con errores: 
+### Ejemplo de salida para endpoints con errores: 
 
 ```
 jquispe@pc1-quispe:~/Escritorio/cursos/Actividades/PracticaCalificada2-CC3S2$ TARGETS="http://localhost:5001 https://endpoint-no-existe.com" ./src/check-endpoint.sh

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -1,6 +1,6 @@
-## Bitácora Sprint-1: Script para monitoreo de endpoints
+# Bitácora Sprint-1: Script para monitoreo de endpoints
 
-- Estudiante: Quispe Villena Renzo
+## Estudiante: Quispe Villena Renzo
 
 - [Video Sprint 1 - Quispe Villena Renzo](https://drive.google.com/file/d/1AdOG4_2TtodTTUVzU8rHmtlm9IPov9MP/view?usp=sharing)
 
@@ -31,3 +31,92 @@ Explicación de cada fila del archivo `out/latencias.csv`:
 - `http://localhost:3002` falló (0 — servicio no escuchando). En las pruebas si tenía un servicio http en el puerto 3001 pero no el 3002.
 - `http://github.com` respondió 301 (redirección a HTTPS) en 356 ms. Exit code = 1 por los fallos de conexión. Servicio funcionando en https no en http.
 
+## Estudiante: Flores Esau
+
+Se pretende conseguir automatizar la construccion y el empaquetado
+1. Creacion de directorios y variables en Makefile
+```bash
+SRC_DIR := src
+OUT_DIR := out
+DIST_DIR := dist
+```
+y configuracion de las opciones de ejecucion
+```bash
+.SHELLFLAGS := -o errexit -o nounset -o pipefail -c
+MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
+.DELETE_ON_ERROR:
+```
+2. Targets<br>
+Ademas de los targets tools , deps, clean, help se implementó build  y package.
+```bash
+build: $(OUT_DIR)/monitor.log
+
+$(OUT_DIR)/monitor.log: $(SRC_DIR)/monitor.sh
+	mkdir -p $(@D)
+	$(SHELL) $< > $@
+
+package: $(DIST_DIR)/monitor.tar.gz
+
+$(DIST_DIR)/monitor.tar.gz: $(OUT_DIR)/monitor.log
+	mkdir -p $(@D)
+	tar --sort=name --owner=0 --group=0 --numeric-owner --mtime='UTC 1970-01-01' -czf $@ -C $(OUT_DIR) monitor.log
+```
+3. El script monitor.sh que a futuro sera sustituido,ocupando su lugar la implementacion de grupo.
+```bash
+resultado=$(curl --write-out "%{http_code} %{time_total}" "$ENDPOINT" )
+http_code=$(echo "$resultado" | awk '{print $1}')
+time_total=$(echo "$resultado" | awk '{print $2}')
+```
+### Resultados obtenidos
+Targets operativos<br>
+Artefacto monitor.log a partir de monitor.sh<br>
+Empaquetado monitor.tar.gz
+
+## Estudiante: Sanchez Vega Andre (rama feature/parser)
+### Rama: feature/parser
+#### Rol en Sprint 1: Definición de contrato CSV + helper lib_csv.sh + prueba Bats
+
+## Tareas realizadas
+- Implementé src/lib_csv.sh con la función csv_append que asegura cabecera y valida campos.
+
+- Creé el archivo docs/contrato-salidas.md con la definición formal del CSV (cabecera, campos, validaciones).
+
+- Desarrollé la primera prueba automatizada en tests/test_monitor.bats siguiendo la técnica AAA/RGR.
+
+- Ajusté el Makefile junto al equipo para que el target test corra Bats.
+
+## Comandos ejecutados
+
+```
+# Ejecutar monitor y generar CSV
+make run
+
+# Validar manualmente que existe el archivo CSV
+ls -l out/latencias.csv
+
+
+# Ejecutar pruebas Bats
+bats tests/test_monitor.bats
+```
+
+## Evidencia de Salida
+
+```
+$ bats tests/test_monitor.bats
+ ✓ monitor genera out/latencias.csv con fila válida
+
+1 test, 0 failures
+```
+
+- Del archivo out/latencias.csv generado:
+```
+ts,target,http_code,time_ms
+2025-09-30T20:19:36Z,http://facebook.com/login,301,69
+2025-09-30T20:19:39Z,http://facebook.com/login,301,29
+```
+
+#### Decisiones tomadas
+
+- Definimos que la cabecera oficial será ts,target,http_code,time_ms.
+- Los tiempos se normalizan en milisegundos enteros para simplificar validación.4
+- La prueba Bats valida que exista el CSV y que cada fila cumpla con el contrato.

--- a/src/lib_csv.sh
+++ b/src/lib_csv.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Archivo CSV configurable por variable de entorno
+CSV_FILE="${CSV_FILE:-out/latencias.csv}"
+
+csv_header() { echo "ts,target,http_code,time_ms"; }
+
+ensure_csv() {
+  mkdir -p "$(dirname "$CSV_FILE")"
+  [[ -f "$CSV_FILE" ]] || csv_header > "$CSV_FILE"
+}
+
+is_http_code() { [[ "${1:-}" =~ ^[0-9]{3}$ ]]; }
+is_uint()      { [[ "${1:-}" =~ ^[0-9]+$   ]]; }
+
+csv_append() {
+  local ts="${1:-}" target="${2:-}" code="${3:-}" ms="${4:-}"
+  ensure_csv
+
+  [[ -n "$ts" && -n "$target" ]] || { echo "csv_append: ts/target vacíos" >&2; return 1; }
+  is_http_code "$code"           || { echo "csv_append: http_code inválido: $code" >&2; return 1; }
+  is_uint "$ms"                  || { echo "csv_append: time_ms inválido: $ms" >&2; return 1; }
+
+  printf '%s,%s,%s,%s\n' "$ts" "$target" "$code" "$ms" >> "$CSV_FILE"
+}

--- a/src/monitor.sh
+++ b/src/monitor.sh
@@ -5,7 +5,11 @@ set -o pipefail
 umask 027
 set -o noclobber
 
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib_csv.sh"
+
 ENDPOINT="${ENDPOINT:-http://facebook.com/login}"
+
 cliente_curl(){
     resultado=$(curl --write-out "%{http_code} %{time_total}" "$ENDPOINT" -o /dev/null)
     http_code=$(echo "$resultado" | awk '{print $1}')
@@ -13,5 +17,9 @@ cliente_curl(){
     echo "endpoint : $ENDPOINT"
     echo "http_code : $http_code"
     echo "time_total : $time_total"
+
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    ms=$(awk -v tt="$time_total" 'BEGIN{printf("%.0f", tt*1000)}')
+    csv_append "$ts" "$ENDPOINT" "$http_code" "$ms"
 }
 cliente_curl

--- a/tests/test_monitor.bats
+++ b/tests/test_monitor.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+setup() {
+  rm -rf out
+  mkdir -p out
+}
+
+@test "monitor genera out/latencias.csv con fila válida" {
+  export TARGETS="https://example.com"
+
+  # Intenta pipeline estándar (Makefile); si no existe, llama script directo
+  run bash -lc 'make run'
+  if [ "$status" -ne 0 ]; then
+    run bash -lc './src/monitor.sh'
+  fi
+
+  # Debe existir CSV
+  [ -f "out/latencias.csv" ]
+
+  # Debe existir una fila (no cabecera) y cumplir regex de validación
+  run bash -lc 'tail -n +2 out/latencias.csv | head -n 1'
+  [ "$status" -eq 0 ]
+
+  # Validar formato: ts,target,http_code,time_ms
+  run bash -lc 'line=$(tail -n +2 out/latencias.csv | head -n1); [[ "$line" =~ ^[^,]+,[^,]+,[0-9]{3},[0-9]+$ ]] && echo OK'
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Qué se hizo:

- Implementé lib_csv.sh con función csv_append.
- Creé el contrato formal del CSV en docs/contrato-salidas.md.
- Añadí prueba automatizada en tests/test_monitor.bats (AAA/RGR).
- Registré evidencias en docs/bitacora-sprint-1.md.

