### PR TITLE
Parser Sprint 2: métricas agregadas y alertas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 .DELETE_ON_ERROR:
 
-.PHONY: tools build test run package clean help deps
+.PHONY: tools build test run package clean help deps parse metrics verify-contratos
 
 SHELLCHECK :=shellcheck
 SHFMT :=shfmt
@@ -19,7 +19,7 @@ $(OUT_DIR)/monitor.log: $(SRC_DIR)/monitor.sh
 	$(SHELL) $< > $@
 
 test: ## ejecuta pruebas bats
-	bats $(TEST_DIR)
+	@bats tests/*.bats
 
 package: $(DIST_DIR)/monitor.tar.gz ## Empaqueta artefactos determinísticamente
 
@@ -48,3 +48,18 @@ help: ## visualizacion de descripcion de targets
 
 run: ## ejecuta monitor y genera CSV
 	@TARGETS=$${TARGETS:-https://example.com} $(SHELL) $(SRC_DIR)/monitor.sh
+
+## Calcula métricas agregadas (resumen) y alertas desde out/latencias.csv
+parse: $(OUT_DIR)/resumen_por_target.csv $(OUT_DIR)/alertas_resumen.csv
+	@echo "[parse] listo: $(OUT_DIR)/resumen_por_target.csv ; $(OUT_DIR)/alertas_resumen.csv"
+
+$(OUT_DIR)/resumen_por_target.csv $(OUT_DIR)/alertas_resumen.csv: $(OUT_DIR)/latencias.csv src/parser_resumen.sh
+	@./src/parser_resumen.sh $(OUT_DIR)/latencias.csv
+
+## Alias de métricas
+metrics: parse
+
+verify-contratos: ## Verifica cabeceras de artefactos
+	@head -1 out/resumen_por_target.csv | grep -qx 'target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts'
+	@head -1 out/alertas_resumen.csv | grep -qx 'timestamp,target,p90_ms,http_codigo,alerta_p90_excede'
+	@echo "[verify] contratos OK"

--- a/docs/Contrato-salidas.md
+++ b/docs/Contrato-salidas.md
@@ -34,6 +34,81 @@ ts,target,http_code,time_ms
 OK: tiene filas
 OK: formato válido
 ```
+
+### Evolución en Sprint 2
+
+**Nota:** ahora `out/latencias.csv` tiene cabecera:
+`timestamp,target,p50,p75,p90,http_codigo`
+
+Campos:
+- timestamp → ISO 8601 UTC
+- target → URL
+- p50, p75, p90 → percentiles de latencia (ms)
+- http_codigo → código de estado HTTP (200,301,404,500,000)
+
+### Artefacto – `out/resumen_por_target.csv`
+**Cabecera obligatoria:**
+target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts
+
+
+**Columnas y significado:**
+- `target` → URL del endpoint medido.
+- `muestras` → cantidad de filas del target en `out/latencias.csv`.
+- `p50_avg_ms`, `p75_avg_ms`, `p90_avg_ms` → promedio de los percentiles p50/p75/p90.
+- `p90_max_ms` → valor máximo de p90 observado para el target.
+- `rate_2xx`, `rate_3xx`, `rate_4xx`, `rate_5xx`, `rate_000` → proporción de respuestas HTTP por familia de códigos.
+- `alertas_p90_excedidas` → número de veces que el p90 superó el umbral `$BUDGET_MS`.
+- `ult_ts` → último timestamp registrado para ese target.
+
+**Validaciones rápidas:**
+```bash
+# Verificar que el archivo existe y tiene al menos una fila
+[ "$(wc -l < out/resumen_por_target.csv)" -ge 2 ] && echo "OK: hay datos"
+
+# Verificar cabecera exacta
+head -1 out/resumen_por_target.csv | grep -qx 'target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts' && echo "OK: cabecera correcta"
+```
+### Ejemplo esperado
+
+```
+target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts
+https://github.com,2,696,1034,1652,2103,1.0000,0.0000,0.0000,0.0000,0.0000,1,2025-10-01T02:20:00Z
+```
+### Artefacto - out/alertas_resumen.csv
+
+**Cabecera obligatoria:**
+
+`timestamp,target,p90_ms,http_codigo,alerta_p90_excede`
+
+**Columnas y significado:**
+
+- `timestamp` → marca de tiempo ISO 8601 UTC (YYYY-MM-DDThh:mm:ssZ).
+
+- `target` → URL del endpoint medido.
+
+- `p90_ms` → valor del percentil 90 calculado para esa corrida.
+
+- `http_codigo` → código HTTP obtenido (200,301,404,500,000).
+
+- `alerta_p90_excede` → indicador (SI o NO) de si el p90 superó el umbral $BUDGET_MS
+
+**Validaciones rápidas:**
+
+```bash
+# Verificar cabecera exacta
+head -1 out/alertas_resumen.csv | grep -qx 'timestamp,target,p90_ms,http_codigo,alerta_p90_excede' && echo "OK: cabecera correcta"
+
+# Verificar si existen alertas activas (p90 > BUDGET_MS)
+grep ',SI$' out/alertas_resumen.csv || echo "Sin alertas por p90"
+```
+### Ejemplo esperado
+```
+timestamp,target,p90_ms,http_codigo,alerta_p90_excede
+2025-10-01T02:17:52Z,https://httpbin.org/status/404,927,404,SI
+2025-10-01T02:20:00Z,https://github.com,1200,200,SI
+OK: cabecera correcta
+OK: validación de alertas
+```
 ## Estudiante: Quispe Villena Renzo
 
 ### Script `check-endpoint.sh` para monitoreo de endpoints

--- a/docs/bitacora-sprint2.md
+++ b/docs/bitacora-sprint2.md
@@ -34,3 +34,102 @@ Explicación de cada fila del archivo `out/latencias.csv`:
 - `http://localhost:3001`: falló (0 — servicio no escuchando).
 
 En casos donde el host no exista (por ejemplo `https://endpoint-no-existe.com`) o el puerto no tenga un servicio escuchando (como `http://localhost:3001`), se obtiene código 000 y latencias en 0, lo que indica fallo de conexión.
+
+
+## Estudiante: Sanchez Vega Andre Alvaro
+
+### Objetivo de mi parte en Sprint 2
+Implementar un **parser robusto en Bash** (`src/parser_resumen.sh`) que procese el archivo de entrada `out/latencias.csv` generado por el Integrante A y produzca:
+1. `out/resumen_por_target.csv` → métricas agregadas por cada endpoint (p50/p75/p90 promedio, p90 máximo, tasas de códigos HTTP, alertas acumuladas, último timestamp).
+2. `out/alertas_resumen.csv` → registro de alertas fila a fila (si p90 excede `$BUDGET_MS`).
+
+Además:
+- Integrar el parser con el **Makefile** (`make parse`).
+- Validar **idempotencia** (no recalcular si no cambian entradas).
+- Escribir **pruebas Bats** que confirmen cabeceras, idempotencia y manejo de errores.
+
+### Entrada consumida
+Archivo `out/latencias.csv` generado por el script `check-endpoint.sh` (Integrante A).
+
+Cabecera esperada en Sprint 2:
+```
+timestamp,target,p50,p75,p90,http_codigo
+```
+
+### Artefactos generados por mi parser
+- **out/resumen_por_target.csv**
+  ```
+  target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts
+  https://github.com,1,892,1268,2103,2103,1.0000,0.0000,0.0000,0.0000,0.0000,1,2025-10-01T02:17:52Z
+  http://github.com,1,209,211,211,211,0.0000,1.0000,0.0000,0.0000,0.0000,0,2025-10-01T02:17:52Z
+  https://httpbin.org/status/404,1,436,797,927,927,0.0000,0.0000,1.0000,0.0000,0.0000,0,2025-10-01T02:17:52Z
+  http://localhost:3001,1,0,0,0,0,0.0000,0.0000,0.0000,0.0000,1.0000,0,2025-10-01T02:17:52Z
+  ```
+
+- **out/alertas_resumen.csv**
+  ```
+  timestamp,target,p90_ms,http_codigo,alerta_p90_excede
+  2025-10-01T02:17:52Z,https://github.com,2103,200,SI
+  2025-10-01T02:17:52Z,http://github.com,211,301,NO
+  2025-10-01T02:17:52Z,https://httpbin.org/status/404,927,404,NO
+  2025-10-01T02:17:52Z,http://localhost:3001,0,000,NO
+  ```
+
+### Ejecución y validaciones
+
+**1. Generar artefactos**
+```bash
+BUDGET_MS=950 make parse
+[parser] generado: out/resumen_por_target.csv y out/alertas_resumen.csv
+[parse] listo: out/resumen_por_target.csv ; out/alertas_resumen.csv
+```
+
+**2. Validar cabeceras (contrato de salida)**
+```bash
+head -1 out/resumen_por_target.csv | grep -qx 'target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts' && echo "OK resumen"
+# Resultado: OK resumen
+
+head -1 out/alertas_resumen.csv | grep -qx 'timestamp,target,p90_ms,http_codigo,alerta_p90_excede' && echo "OK alertas"
+# Resultado: OK alertas
+```
+
+**3. Verificar alertas activas**
+```bash
+grep ',SI$' out/alertas_resumen.csv || echo "Sin alertas por p90"
+# Resultado: 2025-10-01T02:17:52Z,https://github.com,2103,200,SI
+```
+
+**4. Idempotencia con Make**
+```bash
+time make parse
+# real    0m0.059s
+time make parse
+# real    0m0.031s
+time make parse
+# real    0m0.026s
+```
+> La segunda y tercera ejecución fueron inmediatas porque los archivos de salida ya estaban actualizados. Esto demuestra **caché incremental e idempotencia**.
+
+---
+
+### Pruebas Bats
+
+Archivo: `tests/test_parser_resumen.bats`
+
+Ejecutando:
+```bash
+make test
+```
+
+Resultados:
+```
+test_monitor.bats
+ ✓ monitor genera out/latencias.csv con fila válida
+test_parser_resumen.bats
+ ✓ Parser: genera resumen y alertas con cabeceras correctas
+ ✓ Parser: idempotencia (no recalcula si no cambian entradas)
+ ✓ Parser: falla con cabecera inválida (código 5)
+
+4 tests, 0 failures
+```
+

--- a/src/parser_resumen.sh
+++ b/src/parser_resumen.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IN="${1:-out/latencias.csv}"
+OUT_DIR="out"
+OUT_RESUMEN="$OUT_DIR/resumen_por_target.csv"
+OUT_ALERTAS="$OUT_DIR/alertas_resumen.csv"
+
+mkdir -p "$OUT_DIR"
+
+# Umbral por defecto si no viene de entorno (no romper contrato).
+: "${BUDGET_MS:=1000}"
+
+# ---- Validaciones de contrato de entrada ----
+if [[ ! -f "$IN" ]]; then
+  echo "[parser] no existe archivo de entrada: $IN" >&2
+  exit 5
+fi
+
+if ! head -1 "$IN" | grep -q '^timestamp,target,p50,p75,p90,http_codigo$'; then
+  echo "[parser] cabecera inesperada; se requería: timestamp,target,p50,p75,p90,http_codigo" >&2
+  exit 5
+fi
+
+# ---- Idempotencia ----
+# Si AMBOS outputs existen y son más nuevos que IN, no recalcular.
+if [[ -f "$OUT_RESUMEN" && -f "$OUT_ALERTAS" && "$OUT_RESUMEN" -nt "$IN" && "$OUT_ALERTAS" -nt "$IN" ]]; then
+  echo "[parser] cache vigente: $OUT_RESUMEN ; $OUT_ALERTAS (no se recalcula)"
+  exit 0
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+# ---- Normalización segura de filas (fuerza enteros) ----
+tail -n +2 "$IN" | awk -F',' '
+  function isnum(x){ return (x ~ /^[0-9]+$/) }
+  {
+    ts=$1; tgt=$2; p50=$3; p75=$4; p90=$5; code=$6;
+    if (ts=="" || tgt=="") next;
+    if (!isnum(p50)) p50=0;
+    if (!isnum(p75)) p75=0;
+    if (!isnum(p90)) p90=0;
+    if (!isnum(code)) code=0;
+    print ts "," tgt "," p50 "," p75 "," p90 "," code;
+  }
+' > "$TMP"
+
+# ---- Alertas fila a fila (p90 vs BUDGET_MS) ----
+echo "timestamp,target,p90_ms,http_codigo,alerta_p90_excede" > "$OUT_ALERTAS"
+awk -F',' -v B="$BUDGET_MS" '
+  { alert = ($5 > B ? "SI" : "NO"); print $1 "," $2 "," $5 "," $6 "," alert }
+' "$TMP" >> "$OUT_ALERTAS"
+
+# ---- Resumen por target ----
+# - Promedios p50/p75/p90
+# - p90 máximo
+# - tasas por familia HTTP (2xx,3xx,4xx,5xx,000)
+# - conteo de alertas por target (p90 > BUDGET_MS)
+# - último timestamp lexicográficamente mayor (RFC3339)
+echo "target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts" > "$OUT_RESUMEN"
+
+awk -F',' -v B="$BUDGET_MS" '
+{
+  tgt=$2; p50=$3+0; p75=$4+0; p90=$5+0; code=$6+0; ts=$1;
+
+  n[tgt]++; s50[tgt]+=p50; s75[tgt]+=p75; s90[tgt]+=p90;
+  if (p90 > m90[tgt]) m90[tgt]=p90;
+
+  if (code>=200 && code<300) c2[tgt]++;
+  else if (code>=300 && code<400) c3[tgt]++;
+  else if (code>=400 && code<500) c4[tgt]++;
+  else if (code>=500 && code<600) c5[tgt]++;
+  else c0[tgt]++;
+
+  if (p90 > B) a[tgt]++;
+  if (ts > last[tgt]) last[tgt]=ts;
+}
+END{
+  for (t in n) {
+    nn=n[t]+0
+    printf "%s,%d,%.0f,%.0f,%.0f,%.0f,%.4f,%.4f,%.4f,%.4f,%.4f,%d,%s\n",
+      t, nn,
+      (nn? s50[t]/nn:0),(nn? s75[t]/nn:0),(nn? s90[t]/nn:0),(m90[t]+0),
+      (nn? c2[t]/nn:0),(nn? c3[t]/nn:0),(nn? c4[t]/nn:0),(nn? c5[t]/nn:0),(nn? c0[t]/nn:0),
+      (a[t]+0),(last[t]?last[t]:"")
+  }
+}
+' "$TMP" | sort -t, -k1,1 >> "$OUT_RESUMEN"
+
+echo "[parser] generado: $OUT_RESUMEN y $OUT_ALERTAS"

--- a/tests/test_parser_resumen.bats
+++ b/tests/test_parser_resumen.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+  rm -rf out
+  mkdir -p out
+  cat > out/latencias.csv <<'CSV'
+timestamp,target,p50,p75,p90,http_codigo
+2025-10-01T02:17:52Z,https://github.com,892,1268,2103,200
+2025-10-01T02:17:52Z,http://github.com,209,211,211,301
+2025-10-01T02:17:52Z,https://httpbin.org/status/404,436,797,927,404
+2025-10-01T02:17:52Z,http://localhost:3001,0,0,0,000
+2025-10-01T02:20:00Z,https://github.com,500,800,1200,200
+CSV
+}
+
+@test "Parser: genera resumen y alertas con cabeceras correctas" {
+  run env BUDGET_MS=1000 ./src/parser_resumen.sh out/latencias.csv
+  [ "$status" -eq 0 ]
+  [ -f "out/resumen_por_target.csv" ]
+  [ -f "out/alertas_resumen.csv" ]
+
+  run head -1 out/resumen_por_target.csv
+  [[ "$output" =~ target,muestras,p50_avg_ms,p75_avg_ms,p90_avg_ms,p90_max_ms,rate_2xx,rate_3xx,rate_4xx,rate_5xx,rate_000,alertas_p90_excedidas,ult_ts ]]
+
+  run head -1 out/alertas_resumen.csv
+  [[ "$output" =~ timestamp,target,p90_ms,http_codigo,alerta_p90_excede ]]
+}
+
+@test "Parser: idempotencia (no recalcula si no cambian entradas)" {
+  env BUDGET_MS=1000 ./src/parser_resumen.sh out/latencias.csv
+  ts1=$(stat -c %Y out/resumen_por_target.csv)
+  sleep 1
+  run env BUDGET_MS=1000 ./src/parser_resumen.sh out/latencias.csv
+  [ "$status" -eq 0 ]
+  ts2=$(stat -c %Y out/resumen_por_target.csv)
+  [ "$ts1" -eq "$ts2" ]
+}
+
+@test "Parser: falla con cabecera inválida (código 5)" {
+  echo "bad,header" > out/latencias.csv
+  run ./src/parser_resumen.sh out/latencias.csv
+  [ "$status" -eq 5 ]
+}


### PR DESCRIPTION
¿Qué se hizo?

- Implementé el parser (src/parser_resumen.sh) que procesa out/latencias.csv y genera:
out/resumen_por_target.csv con métricas agregadas (p50/p75/p90 promedios, p90 máximo, tasas de códigos HTTP, conteo de alertas, último timestamp).
out/alertas_resumen.csv con alertas fila a fila (p90 vs $BUDGET_MS).
- Se integró el parser al Makefile con el target parse y alias metrics, respetando caché incremental e idempotencia.
- Se añadieron pruebas Bats (tests/test_parser_resumen.bats) que validan:
Generación de los dos CSV con cabeceras correctas.
Idempotencia (no recalcula si no cambian entradas).
Fallo controlado (código 5) si la cabecera es inválida.
- Se actualizó el contrato de salidas (docs/contrato-salidas.md) para documentar los artefactos del Sprint 2.
- Se agregó la bitácora del Sprint 2 (docs/bitacora-sprint-2.md) con evidencias, comandos, ejemplos y resultados.